### PR TITLE
Fix PersonID naming

### DIFF
--- a/FPGA/Testing/FPGATestConfig.cs
+++ b/FPGA/Testing/FPGATestConfig.cs
@@ -8,7 +8,7 @@ namespace FPGA
 {
     public class FPGATestConfig
     {
-        public string PersionID { get; set; } = null;
+        public string PersonID { get; set; } = null;
 
         public string TestFile { get; set; } = null;
 

--- a/FPGA_DNAProcessor/bDNA_Solver.cs
+++ b/FPGA_DNAProcessor/bDNA_Solver.cs
@@ -281,17 +281,17 @@ namespace FPGA_DNAProcessor
                 {
                     backgroundWorker.ReportProgress(1, ".");
 
-                    string PersionID = Guid.NewGuid().ToString();
+                    string PersonID = Guid.NewGuid().ToString();
 
                     FPGAPerson PersonData = new FPGAPerson()
                     {
-                        ID = PersionID,
+                        ID = PersonID,
                         Data = FPGABoard.RandomConfig(TestRequest.SquareSize).ToBitArrayTable(FPGAConfig.BytesPerCell, TestRequest.SquareSize),
                         Results = new List<string>(),
                         Weight = 0
                     };
 
-                    Population.Add(PersionID, PersonData);
+                    Population.Add(PersonID, PersonData);
                 }
 
                 backgroundWorker.ReportProgress(1, "done");
@@ -339,7 +339,7 @@ namespace FPGA_DNAProcessor
             {
                 FPGATestConfig testRunConfig = new FPGATestConfig()
                 {
-                    PersionID = (string)person.Key,
+                    PersonID = (string)person.Key,
                     InputCount = TestRequest.InputCount,
                     OutputCount = TestRequest.OutputCount,
                     TestFile = TestRequest.TestInputsFile
@@ -388,7 +388,7 @@ namespace FPGA_DNAProcessor
 
         protected void ProcessTestRun(FPGATestConfig testReq)
         {
-            FPGAPerson personData = GetPersonFromPopulation(testReq.PersionID);
+            FPGAPerson personData = GetPersonFromPopulation(testReq.PersonID);
 
             //Setup FPGA Board
             FPGABoard testBoard = new FPGABoard(personData.Data, testReq.InputCount, testReq.OutputCount)
@@ -482,7 +482,7 @@ namespace FPGA_DNAProcessor
             //{
             //    results[i] = personData.Results[i];
             //}
-            //string fileToWrite = string.Format(@"{0}\{1}.txt", OutputDNADir, testReq.PersionID);
+            //string fileToWrite = string.Format(@"{0}\{1}.txt", OutputDNADir, testReq.PersonID);
             //File.WriteAllLines(fileToWrite, results);
 
             //Console.WriteLine("{0} Tests: {1}", personData.ID, TestLines.Count());
@@ -874,17 +874,17 @@ namespace FPGA_DNAProcessor
             {
                 backgroundWorker.ReportProgress(1, ".");
 
-                string PersionID = Guid.NewGuid().ToString();
+                string PersonID = Guid.NewGuid().ToString();
 
                 FPGAPerson PersonData = new FPGAPerson()
                 {
-                    ID = PersionID,
+                    ID = PersonID,
                     Data = newHold[i],
                     Results = new List<string>(),
                     Weight = 0
                 };
 
-                Population.Add(PersionID, PersonData);
+                Population.Add(PersonID, PersonData);
             }
 
             backgroundWorker.ReportProgress(1, "done");

--- a/FPGA_Simulator/MainForm.cs
+++ b/FPGA_Simulator/MainForm.cs
@@ -116,7 +116,7 @@ namespace FPGA_Simulator
         
         protected void ProcessTestRun()
         {
-            //FPGAPerson personData = GetPersonFromPopulation(testReq.PersionID);
+            //FPGAPerson personData = GetPersonFromPopulation(testReq.PersonID);
 
             //Setup FPGA Board
             FPGABoard testBoard = FPGA_Controller;


### PR DESCRIPTION
## Summary
- fix spelling from `PersionID` to `PersonID` in `FPGATestConfig`
- update bDNA solver for new property name
- adjust comment in `MainForm` to new name

## Testing
- `dotnet build "FPGA bDNA Processing.sln"` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68659c8c69e4832a966f3b3d1b24ff29