### PR TITLE
Fix typographical error in FPGACell comments

### DIFF
--- a/FPGA/Cells/FPGACell.cs
+++ b/FPGA/Cells/FPGACell.cs
@@ -315,7 +315,7 @@ namespace FPGA
         }
 
         /// <summary>
-        /// Atempt to register with Board Inputs
+        /// Attempt to register with Board Inputs
         /// </summary>
         protected void RegisterBoardInputs()
         {
@@ -326,7 +326,7 @@ namespace FPGA
         }
 
         /// <summary>
-        /// Atempt to register with Board Outputs
+        /// Attempt to register with Board Outputs
         /// </summary>
         protected void RegisterBoardOutputs()
         {


### PR DESCRIPTION
## Summary
- fix spelling mistakes in `FPGACell.cs` comment blocks

## Testing
- `dotnet build "FPGA bDNA Processing.sln"` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659f72a54c832a907300ccda2a5234