### PR TITLE
Fix multi-input XOR and XNOR

### DIFF
--- a/FPGA/Gates/GATE.cs
+++ b/FPGA/Gates/GATE.cs
@@ -1,4 +1,5 @@
-﻿namespace FPGA
+﻿using System.Linq;
+namespace FPGA
 {
     /// <summary>
     /// Logic Gates
@@ -129,13 +130,7 @@
             if (vals == null || vals.Length == 0)
                 return false;
 
-            bool result = false;
-            for (int i = 0; i < vals.Length; i++)
-            {
-                result ^= vals[i];
-            }
-
-            return result;
+            return vals.Aggregate(false, (current, val) => current ^ val);
         }
         
         /// <summary>


### PR DESCRIPTION
## Summary
- calculate multi-input XOR using `Aggregate`
- make sure `XNOR` relies on `XOR`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659f7b6548832a9d03e1894b9e957d