### PR TITLE
Add NUnit-based gate tests

### DIFF
--- a/FPGA bDNA Processing.sln
+++ b/FPGA bDNA Processing.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportKennethsTestInputs", "ImportKennethsTestInputs\ImportKennethsTestInputs.csproj", "{802E66B5-A865-4A70-BFAB-28D2364E6932}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FPGA.Tests", "FPGA.Tests\FPGA.Tests.csproj", "{BFCF6A6E-5B53-44B6-99E5-49A27BC34134}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,9 +39,13 @@ Global
 		{2228FF84-6DFE-44D9-909F-9DDCC73C0398}.Release|Any CPU.Build.0 = Release|Any CPU
 		{802E66B5-A865-4A70-BFAB-28D2364E6932}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{802E66B5-A865-4A70-BFAB-28D2364E6932}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{802E66B5-A865-4A70-BFAB-28D2364E6932}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{802E66B5-A865-4A70-BFAB-28D2364E6932}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {802E66B5-A865-4A70-BFAB-28D2364E6932}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {802E66B5-A865-4A70-BFAB-28D2364E6932}.Release|Any CPU.Build.0 = Release|Any CPU
+                {BFCF6A6E-5B53-44B6-99E5-49A27BC34134}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BFCF6A6E-5B53-44B6-99E5-49A27BC34134}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BFCF6A6E-5B53-44B6-99E5-49A27BC34134}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {BFCF6A6E-5B53-44B6-99E5-49A27BC34134}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/FPGA.Tests/FPGA.Tests.csproj
+++ b/FPGA.Tests/FPGA.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FPGA\FPGA.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+  </ItemGroup>
+</Project>

--- a/FPGA.Tests/Tests/GateTests.cs
+++ b/FPGA.Tests/Tests/GateTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace FPGA.Tests
+{
+    [TestFixture]
+    public class GateTests
+    {
+        private static IEnumerable<bool[]> GenerateCombinations(int length)
+        {
+            int max = 1 << length;
+            int limit = Math.Min(50, max);
+            for (int i = 0; i < limit; i++)
+            {
+                bool[] combo = new bool[length];
+                for (int b = 0; b < length; b++)
+                {
+                    combo[b] = (i & (1 << b)) != 0;
+                }
+                yield return combo;
+            }
+        }
+
+        private static IEnumerable<TestCaseData> NotCases()
+        {
+            yield return new TestCaseData(true).Returns(false);
+            yield return new TestCaseData(false).Returns(true);
+        }
+
+        [TestCaseSource(nameof(NotCases))]
+        public bool Not_gate_returns_inverse(bool input)
+        {
+            return GATE.NOT(input);
+        }
+
+        private static IEnumerable<TestCaseData> TwoInputCombinations()
+        {
+            yield return new TestCaseData(false, false);
+            yield return new TestCaseData(false, true);
+            yield return new TestCaseData(true, false);
+            yield return new TestCaseData(true, true);
+        }
+
+        [TestCaseSource(nameof(TwoInputCombinations))]
+        public void And_gate_two_input(bool a, bool b)
+        {
+            bool expected = a && b;
+            Assert.AreEqual(expected, GATE.AND(a, b));
+        }
+
+        [TestCaseSource(nameof(TwoInputCombinations))]
+        public void Nand_gate_two_input(bool a, bool b)
+        {
+            bool expected = !(a && b);
+            Assert.AreEqual(expected, GATE.NAND(a, b));
+        }
+
+        [TestCaseSource(nameof(TwoInputCombinations))]
+        public void Or_gate_two_input(bool a, bool b)
+        {
+            bool expected = a || b;
+            Assert.AreEqual(expected, GATE.OR(a, b));
+        }
+
+        [TestCaseSource(nameof(TwoInputCombinations))]
+        public void Nor_gate_two_input(bool a, bool b)
+        {
+            bool expected = !(a || b);
+            Assert.AreEqual(expected, GATE.NOR(a, b));
+        }
+
+        [TestCaseSource(nameof(TwoInputCombinations))]
+        public void Xor_gate_two_input(bool a, bool b)
+        {
+            bool expected = a ^ b;
+            Assert.AreEqual(expected, GATE.XOR(a, b));
+        }
+
+        [TestCaseSource(nameof(TwoInputCombinations))]
+        public void Xnor_gate_two_input(bool a, bool b)
+        {
+            bool expected = !(a ^ b);
+            Assert.AreEqual(expected, GATE.XNOR(a, b));
+        }
+
+        private static IEnumerable<TestCaseData> MultiInputCombinations()
+        {
+            foreach (var combo in GenerateCombinations(5))
+                yield return new TestCaseData(combo);
+        }
+
+        [TestCaseSource(nameof(MultiInputCombinations))]
+        public void And_gate_multi_input(bool[] values)
+        {
+            bool expected = values.Length < 2 ? false : values.All(v => v);
+            Assert.AreEqual(expected, GATE.AND(values));
+        }
+
+        [TestCaseSource(nameof(MultiInputCombinations))]
+        public void Nand_gate_multi_input(bool[] values)
+        {
+            bool and = values.Length < 2 ? false : values.All(v => v);
+            bool expected = !and;
+            Assert.AreEqual(expected, GATE.NAND(values));
+        }
+
+        [TestCaseSource(nameof(MultiInputCombinations))]
+        public void Or_gate_multi_input(bool[] values)
+        {
+            bool expected = values.Length < 2 ? false : values.Any(v => v);
+            Assert.AreEqual(expected, GATE.OR(values));
+        }
+
+        [TestCaseSource(nameof(MultiInputCombinations))]
+        public void Nor_gate_multi_input(bool[] values)
+        {
+            bool or = values.Length < 2 ? false : values.Any(v => v);
+            bool expected = !or;
+            Assert.AreEqual(expected, GATE.NOR(values));
+        }
+
+        [TestCaseSource(nameof(MultiInputCombinations))]
+        public void Xor_gate_multi_input(bool[] values)
+        {
+            bool result = false;
+            foreach (bool b in values) result ^= b;
+            bool expected = result;
+            Assert.AreEqual(expected, GATE.XOR(values));
+        }
+
+        [TestCaseSource(nameof(MultiInputCombinations))]
+        public void Xnor_gate_multi_input(bool[] values)
+        {
+            bool result = false;
+            foreach (bool b in values) result ^= b;
+            bool expected = !result;
+            Assert.AreEqual(expected, GATE.XNOR(values));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `FPGA.Tests` project using NUnit
- include gate tests covering NOT, AND, NAND, OR, NOR, XOR and XNOR for two and multi-input cases
- add the new test project to the solution

## Testing
- `dotnet test FPGA.Tests/FPGA.Tests.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68659ffb1750832a9ab4221f799eb86d